### PR TITLE
Reduce CPU usage in the idle event

### DIFF
--- a/Revit.Async.Shared/Entities/FutureExternalEvent.cs
+++ b/Revit.Async.Shared/Entities/FutureExternalEvent.cs
@@ -93,7 +93,6 @@ namespace Revit.Async.Entities
 
         private static void Application_Idling(object sender, IdlingEventArgs e)
         {
-            e.SetRaiseWithoutDelay();
             while (UnlockKeys.TryDequeue(out var unlockKey))
             {
                 unlockKey.Dispose();


### PR DESCRIPTION
Raising idle without delay pegs CPU usage for Revit.  I've been running a modified version of Revit.Async without the call to raise without delay since March of 2023, I don't believe this call is necessary.